### PR TITLE
Added check for correct root disk and skip speed test

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Just copy and paste the following command in your Raspberry Pi console:
 
 The rpi-benchmark script will start in 2 seconds :relaxed:
 <br>
+If you want to run this without the Internet Speed Test being run, then use:
+
+     curl -L https://raw.githubusercontent.com/aikoncwd/rpi-benchmark/master/rpi-benchmark.sh | sudo bash -s -- --no-speedtest
+
 <br>
 <br>
 ## Overclocking

--- a/rpi-benchmark.sh
+++ b/rpi-benchmark.sh
@@ -52,7 +52,7 @@ sysbench --num-threads=4 --validate=on --test=memory --memory-block-size=1K --me
 vcgencmd measure_temp
 echo -e "\e[93m"
 
-echo -e "Running HDPARM test...\e[94m"
+echo -e "Running HDPARM test on ${ROOTDISK}...\e[94m"
 hdparm -t ${ROOTDISK} | grep Timing
 vcgencmd measure_temp
 echo -e "\e[93m"

--- a/rpi-benchmark.sh
+++ b/rpi-benchmark.sh
@@ -9,9 +9,19 @@ fi
 if [ ! `which sysbench` ]; then
   apt-get install -y sysbench
 fi
-if [ ! `which speedtest-cli` ]; then
-  apt-get install -y speedtest-cli
-fi
+
+# Skip the speed test if the user doesn't want it to run
+case $1 in
+    --no-speedtest|-ns )
+        echo "Skipping speed test"
+        echo
+        ;;
+    * )
+        if [ ! `which speedtest-cli` ]; then
+          apt-get install -y speedtest-cli
+        fi
+        ;;
+esac
 
 # Get root disk for hdparam test
 ROOTDISK=`mount | grep " on / type" | cut -f 1 -d " "`
@@ -33,6 +43,7 @@ printf "sd_clock="
 grep "actual clock" /sys/kernel/debug/mmc0/ios 2>/dev/null | awk '{printf("%0.3f MHz", $3/1000000)}'
 echo -e "\n\e[93m"
 
+# Skip the speed test if the user doesn't want it to run
 case $1 in
     --no-speedtest|-ns )
         echo "Skipping speed test"

--- a/rpi-benchmark.sh
+++ b/rpi-benchmark.sh
@@ -13,6 +13,9 @@ if [ ! `which speedtest-cli` ]; then
   apt-get install -y speedtest-cli
 fi
 
+# Get root disk for hdparam test
+ROOTDISK=`mount | grep " on / type" | cut -f 1 -d " "`
+
 # Script start!
 clear
 sync
@@ -50,7 +53,7 @@ vcgencmd measure_temp
 echo -e "\e[93m"
 
 echo -e "Running HDPARM test...\e[94m"
-hdparm -t /dev/mmcblk0 | grep Timing
+hdparm -t ${ROOTDISK} | grep Timing
 vcgencmd measure_temp
 echo -e "\e[93m"
 

--- a/rpi-benchmark.sh
+++ b/rpi-benchmark.sh
@@ -33,9 +33,17 @@ printf "sd_clock="
 grep "actual clock" /sys/kernel/debug/mmc0/ios 2>/dev/null | awk '{printf("%0.3f MHz", $3/1000000)}'
 echo -e "\n\e[93m"
 
-echo -e "Running InternetSpeed test...\e[94m"
-speedtest-cli --simple
-echo -e "\e[93m"
+case $1 in
+    --no-speedtest|-ns )
+        echo "Skipping speed test"
+        echo
+        ;;
+    * )
+        echo -e "Running InternetSpeed test...\e[94m"
+        speedtest-cli --simple
+        echo -e "\e[93m"
+        ;;
+esac
 
 echo -e "Running CPU test...\e[94m"
 sysbench --num-threads=4 --validate=on --test=cpu --cpu-max-prime=5000 run | grep 'total time:\|min:\|avg:\|max:' | tr -s [:space:]


### PR DESCRIPTION
Two small changes made. The first is the option to skip the Internet Speedtest, sadly the speedtest-cli tool is no longer a valid way to check speeds, it's highly inaccurate and even more so on Raspberry Pi's for some reason. So I've added an option to call it with `-ns` or `--no-speedtest`. Doing so will simply skip the test.  I've also updated the `README.md` with an alternative curl command so it can still be run with a single command.

The second change was to add a line to fetch the current root disk device name and use that for the HDPARM test, the hardcoded `/dev/mmcblk0` doesn't work if you boot from USB like a lot of people do. The change made was just to grab the actual root disk name, then run hdparm against that, output example from my SanDisk Extreme 1TB USB drive

```
Running HDPARM test...
 Timing buffered disk reads: 1076 MB in  3.00 seconds = 358.18 MB/sec
temp=43.0'C
```

I hope this use a useful change, I'm sure it will be for a lot of USB booting folks.

Thanks